### PR TITLE
Fix the delay parameter

### DIFF
--- a/gfx2gf.sh
+++ b/gfx2gf.sh
@@ -149,7 +149,7 @@ for input_path in "$@"; do
         if [ "$delay" -lt 4 ]; then
             delay=4
         fi
-        delay=$(($delay * 4))
+        delay=$(($delay * 10))
 
         # Write config.ini using stored delay value
         echo "# All of these settings are optional. 


### PR DESCRIPTION
The bash script seems to interpret the output of the inspect command. According to [the documentation](http://www.imagemagick.org/script/escape.php), %T outputs `image time delay (in centi-seconds)`, and yet the script only multiplies by 4 when converting to milliseconds.

This pull fixes that, by multiplying by 10 instead.
